### PR TITLE
MongoDB admin interface + Docker setup

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,8 +1,13 @@
-FROM node:12.16.0-buster
-
+FROM node:fermium-alpine AS build
 WORKDIR /app
-
 COPY package*.json ./
+RUN apk add git && npm install
+COPY ./ ./
+RUN npm run build
+EXPOSE 8080
+ENTRYPOINT ["npm", "run", "serve"]
 
-COPY . .
-
+FROM nginx:alpine
+COPY --from=build /app/dist /var/www/html/
+COPY ./nginx/dev.conf /etc/nginx/sites-enabled/
+COPY ./nginx/nginx.conf /etc/nginx/

--- a/client/nginx/dev.conf
+++ b/client/nginx/dev.conf
@@ -1,0 +1,22 @@
+server {
+ 	listen 80 default;
+    listen [::]:80 default;
+ 	server_name default;
+ 	root /var/www/html/;
+ 	index index.html;
+
+ 	location = /favicon.png {
+ 		log_not_found off;
+ 		access_log off;
+ 	}
+
+ 	location = /robots.txt {
+ 		allow all;
+ 		log_not_found off;
+ 		access_log off;
+ 	}
+
+ 	location / {
+         try_files $uri $uri/ /index.html;
+    }
+}

--- a/client/nginx/nginx.conf
+++ b/client/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/sites-enabled/*;
+}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,21 @@
+version: "3.7"
+
+services:
+
+  client:
+    build:
+      target: build
+    ports:
+    - "8080:8080"
+    volumes:
+      - /app/node_modules
+      - ./client:/app
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+
+  server:
+    build:
+      target: build
+    volumes:
+      - /app/node_modules
+      - ./server:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,34 @@
-version: '3'
+version: "3.7"
+
 services:
-  vue-client:
-    container_name: "im2-client"
+
+  client:
     build: ./client
-    command: bash -c "npm install && npm run serve"
-    volumes:
-      - /app/node_modules
-      - ./client:/app
+    image: imimap21/client:latest
     ports:
-      - "8080:8080"
+      - "80:80"
 
-  mongo:
-    container_name: "im2-db"
-    image: library/mongo:4.2-bionic
-    volumes:
-      - ./tmp/data:/data/db
-    ports:
-      - "27017:27017"
-
-  node-server:
-    container_name: "im2-server"
+  server:
     build: ./server
-    command: bash -c "npm install && npm run serve"
-    volumes:
-      - /app/node_modules
-      - ./server:/app
+    image: imimap21/server:latest
     ports:
       - "9000:9000"
+    depends_on:
+      - db
+
+  db:
+    image: mongo:bionic
+    ports:
+      - "27017:27017"
+    volumes:
+      - db-data:/data/db
+
+  db-gui:
+    image: mongo-express
+    ports:
+      - "8081:8081"
+    environment:
+      - ME_CONFIG_MONGODB_SERVER=db
+
+volumes:
+  db-data:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,16 @@
-FROM node:12.16.0-buster
-
+FROM node:fermium-alpine AS build
 WORKDIR /app
-
 COPY package*.json ./
+RUN apk add git && npm install
+COPY ./ ./
+RUN npm run build-ts
+EXPOSE 9000
+ENTRYPOINT ["npm", "run", "watch"]
 
-COPY . .
-
+FROM node:fermium-alpine
+WORKDIR /server
+COPY --from=build /app/package*.json ./
+RUN apk add git && npm ci --only=production
+COPY --from=build /app/dist/ ./dist/
+EXPOSE 9000
+ENTRYPOINT ["npm", "run", "serve"]

--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -1,7 +1,7 @@
-import mongoose from "mongoose";
+import * as mongoose from "mongoose";
 
 async function connect(): Promise<void> {
-  const mongoDB = "mongodb://mongo:27017";
+  const mongoDB = "mongodb://db:27017";
   try {
     await mongoose.connect(mongoDB, { useNewUrlParser: true, useUnifiedTopology: true });
     console.log(`Connection to database at ${mongoDB} successfully established.`);


### PR DESCRIPTION
Closes #9

* Added mongo-express as admin database interface
* Rewrote Dockerfiles to use separate build and deployment target
* Rewrote docker-compose files to allow building for a staging deployment or a local development deployment with file-watching enabled