### PR TITLE
Create update internship module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In the root folder run
 Ctrl + C will stop the containers.
 
 Alternatively use
-`docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d`
+`docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d --build`
 
 In that case, shut down the containers with docker-compose down.
 

--- a/server/src/controllers/internshipModule.ts
+++ b/server/src/controllers/internshipModule.ts
@@ -1,9 +1,10 @@
 import { NextFunction, Request, Response } from "express";
 import { IInternshipModule, InternshipModule } from "../models/internshipModule";
 import { FilterQuery } from "mongoose";
-import { User } from "../models/user";
-import { Forbidden, NotFound } from "http-errors";
+import {IUser, User} from "../models/user";
+import {BadRequest, Forbidden, NotFound} from "http-errors";
 import { Role } from "../authentication/user";
+import {Internship} from "../models/internship";
 
 export async function findInternshipModule(
   req: Request,
@@ -33,4 +34,62 @@ export async function listInternshipModules(req: Request, res: Response): Promis
   const filter: FilterQuery<IInternshipModule> = {};
   if (req.query.semester) filter.inSemester = req.query.semester as string;
   res.json(await InternshipModule.find(filter).lean());
+}
+
+export async function passAep(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const user = await User.findOne({ emailAddress: req.user?.email }).populate({
+    path: "studentProfile",
+    lean: true,
+  });
+  if (!user) return next(new NotFound("User not found"));
+  if (!user.isAdmin) return next(new Forbidden("Only admins may mark the aep as passed"));
+
+  if (!req.params.id)
+    return next(
+      new NotFound("Provide an id in the query to say for internship module to pass the AEP.")
+    );
+  const internshipToUpdate = await InternshipModule.findById(req.params.id);
+  if (!internshipToUpdate) return next(new NotFound("InternshipModule not found"));
+
+  const updatedInternship = await internshipToUpdate.passAep(user._id);
+  res.json(updatedInternship);
+}
+
+export async function createInternshipModule(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  const user = await User.findOne({ emailAddress: req.user?.email }).populate({
+    path: "studentProfile",
+    lean: true,
+  });
+  if (!user) return next(new NotFound("User not found"));
+
+  let userToUpdate: IUser | null = user;
+
+  if (user.isAdmin) {
+    if (!req.query.id)
+      return next(
+        new NotFound(
+          "Provide an id in the query to say for which student to create an internship module."
+        )
+      );
+    userToUpdate = await User.findById(req.query.id);
+    if (!userToUpdate) return next(new NotFound("User not found"));
+  }
+
+  if (!userToUpdate.studentProfile)
+    return next(new NotFound("User does not seem to be a student."));
+
+  if (userToUpdate.studentProfile.internship)
+    return next(new NotFound("Student already has an internship module."));
+
+  const newInternshipModule: IInternshipModule = new InternshipModule({});
+  const createdInternshipModule = await newInternshipModule.plan();
+
+  userToUpdate.studentProfile.internship = createdInternshipModule._id;
+  await userToUpdate.save();
+
+  res.json(createdInternshipModule);
 }

--- a/server/src/routes/internshipModule.ts
+++ b/server/src/routes/internshipModule.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { param, query } from "express-validator";
 import { Semester } from "../helpers/semesterHelper";
 import authMiddleware from "../authentication/middleware";
-import { findInternshipModule, listInternshipModules } from "../controllers/internshipModule";
+import { findInternshipModule, listInternshipModules, passAep, createInternshipModule } from "../controllers/internshipModule";
 import { validate } from "../helpers/validation";
 import * as asyncHandler from "express-async-handler";
 
@@ -25,5 +25,62 @@ internshipModuleRouter.get(
   validate,
   asyncHandler(findInternshipModule)
 );
+
+// todo: the following endpoint might not be needed - isn't a module planned as soon as the first internship(part) is created?
+/*
+internshipModuleRouter.post(
+  "/",
+  authMiddleware(),
+  //query("id").custom((id) => /[0-9a-f]{24}/.test(id) || null),
+  validate,
+  asyncHandler(createInternshipModule)
+);*/
+
+internshipModuleRouter.patch(
+  "/:id/aep-passed/",
+  authMiddleware(true),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  validate,
+  asyncHandler(passAep)
+);
+
+/*
+internshipModuleRouter.post(
+  "/:id/pdf/report",
+  authMiddleware(),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id) || id === "my"),
+  validate,
+  asyncHandler(submitReportPdf)
+);
+ */
+/*
+internshipModuleRouter.patch(
+  "/:id/pdf/report/accepted",
+  authMiddleware(true),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  validate,
+  asyncHandler(acceptReportPdf)
+);
+ */
+/*
+internshipModuleRouter.patch(
+  "/:id/pdf/report/rejected",
+  authMiddleware(true),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  validate,
+  asyncHandler(rejectReportPdf)
+);
+ */
+
+/* Additional admin interface options */
+/*
+internshipModuleRouter.patch(
+  "/:id/",
+  authMiddleware(true),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  validate,
+  asyncHandler(updateInternshipModule)
+);
+ */
 
 export default internshipModuleRouter;

--- a/server/src/routes/internshipModule.ts
+++ b/server/src/routes/internshipModule.ts
@@ -76,6 +76,24 @@ internshipModuleRouter.patch(
   asyncHandler(rejectReportPdf)
 );
  */
+/*
+internshipModuleRouter.get(
+  "/:id/pdf/report/",
+  authMiddleware(),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  validate,
+  asyncHandler(getReportPdf)
+);
+ */
+/*
+internshipModuleRouter.get(
+  "/:id/pdf/complete/",
+  authMiddleware(),
+  param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  validate,
+  asyncHandler(getCompleteDocumentsPdf)
+);
+ */
 
 /* Additional admin interface options */
 internshipModuleRouter.patch(

--- a/server/src/routes/internshipModule.ts
+++ b/server/src/routes/internshipModule.ts
@@ -2,7 +2,12 @@ import { Router } from "express";
 import { param, query } from "express-validator";
 import { Semester } from "../helpers/semesterHelper";
 import authMiddleware from "../authentication/middleware";
-import { findInternshipModule, listInternshipModules, passAep, createInternshipModule } from "../controllers/internshipModule";
+import {
+  findInternshipModule,
+  listInternshipModules,
+  passAep,
+  updateInternshipModule,
+} from "../controllers/internshipModule";
 import { validate } from "../helpers/validation";
 import * as asyncHandler from "express-async-handler";
 
@@ -73,14 +78,21 @@ internshipModuleRouter.patch(
  */
 
 /* Additional admin interface options */
-/*
 internshipModuleRouter.patch(
   "/:id/",
   authMiddleware(true),
   param("id").custom((id) => /[0-9a-f]{24}/.test(id)),
+  query([
+    "internships",
+    "inSemester",
+    "inSemesterOfStudy",
+    "aepPassed",
+    "reportPdf",
+    "completeDocumentsPdf",
+    "status",
+  ]),
   validate,
   asyncHandler(updateInternshipModule)
 );
- */
 
 export default internshipModuleRouter;

--- a/server/test/models/studentProfile.test.ts
+++ b/server/test/models/studentProfile.test.ts
@@ -57,6 +57,8 @@ describe("StudentProfile", () => {
       throw "createdUser or one of its properties is null.";
     }
 
+    expect(createdUser.studentProfile.internship).toBeFalsy();
+
     const internshipObjectId: Types.ObjectId = Types.ObjectId(); // mock an object id
 
     createdUser.studentProfile.internship = internshipObjectId;


### PR DESCRIPTION
- adds admin endpoint to mark internship module aep as passed
- adds admin endpoint to update internship module props by hand (should only be used in worst case - usually we have all the methods we need, eg. the one to mark the aep as passed)
- adds stubs for internship module pdf endpoints

tested :)

As always, documentation is here: https://www.getpostman.com/collections/3406cd53e9316e2cf003