### PR TITLE
Added endpoints for fetching lists of semester identifiers

### DIFF
--- a/server/src/controllers/semester.ts
+++ b/server/src/controllers/semester.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from "express";
+import { Semester } from "../helpers/semesterHelper";
+import { InternshipModule } from "../models/internshipModule";
+
+/**
+ * Returns a list of upcoming semesters, containing the current
+ * semester + <count | 3> additional semesters
+ * @param req
+ * @param res
+ */
+export function getUpcomingSemesters(req: Request, res: Response): void {
+  const count = Number.parseInt(req.query.count as string);
+  const semesters = [Semester.getCurrent()];
+
+  for (let i = 0; i < count; i++) semesters.push(semesters[i].next());
+
+  res.json(semesters.map((s) => s.toString()));
+}
+
+/**
+ * Returns a list of past semesters that contain internships
+ * @param req
+ * @param res
+ */
+export async function getSemesters(req: Request, res: Response): Promise<void> {
+  res.json(await InternshipModule.distinct("inSemester").lean());
+}

--- a/server/src/routes/info.ts
+++ b/server/src/routes/info.ts
@@ -9,6 +9,7 @@ import {
 import { validate } from "../helpers/validation";
 import * as asyncHandler from "express-async-handler";
 import { getAllCountries, getCities } from "../controllers/company";
+import { getSemesters, getUpcomingSemesters } from "../controllers/semester";
 
 const infoRouter = Router();
 
@@ -46,5 +47,14 @@ infoRouter.get(
 );
 
 infoRouter.get("/countries", authMiddleware(), validate, asyncHandler(getAllCountries));
+
+infoRouter.get("/semesters", getSemesters);
+
+infoRouter.get(
+  "/semesters/upcoming",
+  query("count").default(3).isInt(),
+  validate,
+  getUpcomingSemesters
+);
 
 export default infoRouter;


### PR DESCRIPTION
@RobinUndersigned Für die Home-Page und für Postponement Requests. Die gab's ja noch nicht, soweit ich weiß :)

`GET /info/semesters` → Returns list of past semesters containing internships
`GET /info/semesters/upcoming?count=3` → Returns list of upcoming semesters, including the current semester and the next <count> semesters. Count parameter is optional, default is 3