### PR TITLE
Fix/30 previous search results

### DIFF
--- a/client/src/components/search/SearchResult.vue
+++ b/client/src/components/search/SearchResult.vue
@@ -56,13 +56,6 @@ export default defineComponent({
     operationalArea: String,
     programmingLanguages: [String],
   },
-  data() {
-    return {
-    };
-  },
-  methods: {
-
-  },
 });
 </script>
 

--- a/client/src/components/search/SearchResult.vue
+++ b/client/src/components/search/SearchResult.vue
@@ -1,0 +1,71 @@
+<template>
+  <tr>
+    <td>{{ companyName }}</td>
+    <td>{{ companyCity }}</td>
+    <td>{{ operationalArea }}</td>
+    <td>
+      <button class="btn btn-outline-htw-green float-right"
+              data-bs-toggle="collapse"
+              :data-bs-target="'#collapseResult' + id"
+              aria-expanded="false"
+              :aria-controls="'#collapseResult' + id">
+        Details
+      </button>
+    </td>
+  </tr>
+  <tr class="collapse" :id="'collapseResult' + id">
+    <td colspan="7">
+      <p class="pl-3">
+        <strong>{{ $t("search.programmingLanguages") }}</strong>
+        {{
+          programmingLanguages?.length > 0
+            ? programmingLanguages?.toString()
+            :  'Keine Angabe'
+        }}
+      </p>
+      <p class="pl-3">
+        <strong>{{ $t("search.website") }}</strong>
+        <a :href="companyWebsite" target="_blank">
+          {{ companyWebsite }}
+        </a>
+      </p>
+      <p class="pl-3">
+        <strong>{{ $t("search.tasks") }}</strong>
+        {{ tasks }}
+      </p>
+      <p class="pl-3">
+        <strong>{{ $t("search.contact") }}</strong>
+        {{ companyEmail }}
+      </p>
+    </td>
+  </tr>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'SearchResult',
+  props: {
+    id: String,
+    companyCity: String,
+    companyEmail: String,
+    companyName: String,
+    companyWebsite: String,
+    tasks: String,
+    operationalArea: String,
+    programmingLanguages: [String],
+  },
+  data() {
+    return {
+    };
+  },
+  methods: {
+
+  },
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/client/src/components/search/SearchResultList.vue
+++ b/client/src/components/search/SearchResultList.vue
@@ -44,12 +44,5 @@ export default defineComponent({
     resultCountText: String,
     searchResults: [],
   },
-  data() {
-    return {
-    };
-  },
-  methods: {
-
-  },
 });
 </script>

--- a/client/src/components/search/SearchResultList.vue
+++ b/client/src/components/search/SearchResultList.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="container" style="max-width: 100vw;">
+    <p class="text-center p-1">
+      {{ $tc(resultCountText, resultCount) }}
+    </p>
+    <table class="table table-striped table-sm table-borderless text-left">
+      <tbody>
+      <tr>
+        <td class="font-weight-bold">{{ $t("search.company") }}</td>
+        <td class="font-weight-bold">{{ $t("search.location") }}</td>
+        <td class="font-weight-bold">{{ $t("search.orientation") }}</td>
+        <td class="font-weight-bold"></td>
+      </tr>
+      <!-- Result Loop -->
+      <template  v-if="searchResults.length > 0">
+        <template v-for="(searchResult) in searchResults"
+                  v-bind:key="searchResult._id">
+          <SearchResult
+            :id="searchResult._id"
+            :company-city="searchResult.company?.address?.city"
+            :company-email="searchResult.company?.emailAddress"
+            :company-name="searchResult.company?.companyName"
+            :company-website="searchResult.company?.website"
+            :operational-area="searchResult.operationalArea"
+            :programming-languages="searchResult.programmingLanguages"
+            :tasks="searchResult.tasks">
+          </SearchResult>
+        </template>
+      </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+<script lang="ts">
+import Internship from '@/models/Internship';
+import SearchResult from '@/components/search/SearchResult.vue';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'SearchResultList',
+  components: { SearchResult },
+  props: {
+    resultCount: Number,
+    resultCountText: String,
+    searchResults: [],
+  },
+  data() {
+    return {
+    };
+  },
+  methods: {
+
+  },
+});
+</script>

--- a/client/src/locales/de/search.ts
+++ b/client/src/locales/de/search.ts
@@ -27,6 +27,7 @@ const search = {
   + 'mit \n der Programmiersprache {programmingLanguage} ',
   },
   results: {
+    noResults: 'Keine Praktika gefunden. Versuche es mit weniger spezifischen Suchkriterien.',
     resultCount: 'Es wurden 0 Treffer gefunden | Es wurde 1 Treffer gefunden | Es wurden {n} Treffer gefunden',
     previousResultCount: '0 Ergebnisse vorheriger Suchen | 1 Ergebnis vorheriger Suchen | {n} Ergebnisse vorheriger Suchen',
   },

--- a/client/src/locales/en/search.ts
+++ b/client/src/locales/en/search.ts
@@ -26,6 +26,7 @@ const search = {
       + '\n with the programming language {programmingLanguage} ',
   },
   results: {
+    noResults: 'No internships found. Try again with less specific search criteria.',
     resultCount: 'There were 0 results | There was 1 result | There were {n} results',
     previousResultCount: '0 results of previous searches | 1 result of previous searches | {n} results of previous searches',
   },

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -195,7 +195,7 @@ export default defineComponent({
       try {
         const res = await http.get('/info/countries');
         this.availableCountries = await res.data;
-      } catch (err) { // Todo: Ersetzen durch util showErrorMessage
+      } catch (err: any) { // Todo: Ersetzen durch util showErrorMessage
         await this.$store.dispatch('addNotification', {
           text: `Fehler beim laden der verfügbaren Länder [ERROR: ${err.message}]`,
           type: 'danger',
@@ -206,7 +206,7 @@ export default defineComponent({
       try {
         const res = await http.get('/info/payment-types');
         this.availablePaymentOptions = res.data;
-      } catch (err) {
+      } catch (err: any) {
         await this.$store.dispatch('addNotification', {
           text: `Fehler beim laden der verfügbaren Bezahlungsmodelle [ERROR: ${err.message}]`,
           type: 'danger',
@@ -217,7 +217,7 @@ export default defineComponent({
       try {
         const res = await http.get('/info/operational-areas');
         this.availableOperationalAreas = res.data;
-      } catch (err) {
+      } catch (err: any) {
         await this.$store.dispatch('addNotification', {
           text: `Fehler beim laden der verfügbaren Bereiche [ERROR: ${err.message}]`,
           type: 'danger',
@@ -228,7 +228,7 @@ export default defineComponent({
       try {
         const res = await http.get('/info/programming-languages');
         this.availableLanguages = res.data;
-      } catch (err) {
+      } catch (err: any) {
         await this.$store.dispatch('addNotification', {
           text: `Fehler beim laden der verfügbaren Programmiersprachen [ERROR: ${err.message}]`,
           type: 'danger',
@@ -269,7 +269,7 @@ export default defineComponent({
           },
         });
         return res.data;
-      } catch (err) {
+      } catch (err: any) {
         throw new Error(`Fehler beim Suchen nach Praktika [ERROR: ${err.message}]`);
       }
     },

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -247,7 +247,6 @@ export default defineComponent({
           type: 'danger',
         });
       }
-      console.log(this.searchResults.length);
       try {
         this.previousSearchResults = await this.getSearchResults(true);
       } catch (e: any) {
@@ -256,7 +255,6 @@ export default defineComponent({
           type: 'danger',
         });
       }
-      console.log(this.previousSearchResults.length);
       this.loadingState = false;
     },
     async getSearchResults(seen: boolean) {

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -107,10 +107,12 @@
     </div>
   </div>
   <!-- Search Results -->
-  <div id="form-block4" class="mx-3 my-3" v-if="!loadingState && searchResults.length <= 0">
+  <div id="form-block4" class="mx-3 my-3"
+       v-if="!loadingState && searchResults.length <= 0 && previousSearchResults.length <= 0">
     {{ $t("search.results.noResults") }}
   </div>
-  <div id="form-block4" class="mx-3 my-3" v-if="!loadingState && searchResults.length > 0">
+  <div id="form-block4" class="mx-3 my-3"
+       v-if="!loadingState && (searchResults.length > 0 || previousSearchResults.length > 0)">
     <div class="text-center">
       <button type="button"
               class="btn btn-htw-green text-white mb-3"
@@ -118,12 +120,15 @@
         {{ $t("search.showMap") }}
       </button>
     </div>
-    <div id="search-results" class="search_results" v-if="!cardToggle">
+    <div id="search-results" class="search_results" v-if="!cardToggle && searchResults.length > 0">
       <SearchResultList
         :result-count="resultCount"
         :search-results="searchResults"
         result-count-text="search.results.resultCount">
       </SearchResultList>
+    </div>
+    <div id="previous-search-results" class="search_results"
+         v-if="!cardToggle && previousSearchResults.length > 0">
       <SearchResultList
         :result-count="previousResultCount"
         :search-results="previousSearchResults"
@@ -242,6 +247,7 @@ export default defineComponent({
           type: 'danger',
         });
       }
+      console.log(this.searchResults.length);
       try {
         this.previousSearchResults = await this.getSearchResults(true);
       } catch (e: any) {
@@ -250,6 +256,7 @@ export default defineComponent({
           type: 'danger',
         });
       }
+      console.log(this.previousSearchResults.length);
       this.loadingState = false;
     },
     async getSearchResults(seen: boolean) {

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -238,9 +238,7 @@ export default defineComponent({
     async searchRequest() {
       this.loadingState = true;
       try {
-        this.searchResults = await this.getSearchResults(false);
-        // this.searchResults = this.searchResults.filter((internship) =>
-        // typeof internship.company.address !== 'undefined');
+        this.previousSearchResults = await this.getSearchResults(true);
       } catch (e: any) {
         await this.$store.dispatch('addNotification', {
           text: e.message,
@@ -248,7 +246,9 @@ export default defineComponent({
         });
       }
       try {
-        this.previousSearchResults = await this.getSearchResults(true);
+        this.searchResults = await this.getSearchResults(false);
+        // this.searchResults = this.searchResults.filter((internship) =>
+        // typeof internship.company.address !== 'undefined');
       } catch (e: any) {
         await this.$store.dispatch('addNotification', {
           text: e.message,

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -119,71 +119,16 @@
       </button>
     </div>
     <div id="search-results" class="search_results" v-if="!cardToggle">
-      <div class="container" style="max-width: 100vw;">
-        <p class="text-center p-1">
-          {{ $tc("search.results.resultCount", resultCount) }}
-        </p>
-        <!-- @TODO: %count% Ergebnisse aus vorherigen suchen implementieren-->
-        <p class="text-center p-1" v-if="false">
-          {{ $tc("search.results.previousResultCount", resultCount) }}
-        </p>
-        <table class="table table-striped table-sm table-borderless text-left">
-          <tbody>
-          <tr>
-            <td class="font-weight-bold">{{ $t("search.company") }}</td>
-            <td class="font-weight-bold">{{ $t("search.location") }}</td>
-            <td class="font-weight-bold">{{ $t("search.orientation") }}</td>
-            <td class="font-weight-bold"></td>
-          </tr>
-          <!-- Result Loop -->
-          <template  v-if="searchResults?.length > 0">
-            <template v-for="(searchResult) in searchResults"
-                      v-bind:key="searchResult._id">
-              <tr>
-                <td>{{ searchResult?.company?.companyName }}</td>
-                <td> {{ searchResult?.company?.address?.city }}</td>
-                <td> {{ searchResult?.operationalArea }}</td>
-                <td>
-                  <button class="btn btn-outline-htw-green float-right"
-                          data-bs-toggle="collapse"
-                          :data-bs-target="'#collapseResult' + searchResult._id"
-                          aria-expanded="false"
-                          :aria-controls="'#collapseResult' + searchResult._id">
-                    Details
-                  </button>
-                </td>
-              </tr>
-              <tr class="collapse" :id="'collapseResult' + searchResult._id">
-                <td colspan="7">
-                  <p class="pl-3">
-                    <strong>{{ $t("search.programmingLanguages") }}</strong>
-                    {{
-                      searchResult.programmingLanguages?.length > 0
-                        ? searchResult.programmingLanguages?.toString()
-                        :  'Keine Angabe'
-                    }}
-                  </p>
-                  <p class="pl-3">
-                    <strong>{{ $t("search.website") }}</strong>
-                    <a :href="searchResult?.company?.website" target="_blank">
-                      {{ searchResult?.company?.website }}
-                    </a>
-                  </p>
-                  <p class="pl-3">
-                    <strong>{{ $t("search.tasks") }}</strong>
-                    {{ searchResult?.tasks }}
-                  </p>
-                  <p class="pl-3">
-                    <strong>{{ $t("search.contact") }}</strong>
-                    {{ searchResult?.company?.emailAddress }}
-                  </p>
-                </td>
-              </tr>
-            </template>
-          </template>
-          </tbody>
-        </table>
-      </div>
+      <SearchResultList
+        :result-count="resultCount"
+        :search-results="searchResults"
+        result-count-text="search.results.resultCount">
+      </SearchResultList>
+      <SearchResultList
+        :result-count="previousResultCount"
+        :search-results="previousSearchResults"
+        result-count-text="search.results.previousResultCount">
+      </SearchResultList>
     </div>
     <div id="map-results">
       <Map v-if="cardToggle" :locations="locations"></Map>
@@ -198,10 +143,11 @@ import Map from '@/components/Map.vue';
 import http from '@/utils/http-common';
 import { Internship } from '@/store/types/Internship';
 import { MapLocation } from '@/store/types/MapLocation';
+import SearchResultList from '@/components/search/SearchResultList.vue';
 
 export default defineComponent({
   name: 'Search',
-  components: { Map },
+  components: { SearchResultList, Map },
   data() {
     return {
       // Available filters after query
@@ -211,6 +157,7 @@ export default defineComponent({
       availableLanguages: null,
       // Searchresults after query
       searchResults: [] as Internship[],
+      previousSearchResults: [] as Internship[],
       // Selected filters
       paymentFilter: null,
       countryFilter: null,
@@ -224,6 +171,9 @@ export default defineComponent({
   computed: {
     resultCount(): number {
       return this.searchResults.length;
+    },
+    previousResultCount(): number {
+      return this.previousSearchResults.length;
     },
     locations(): MapLocation[] | null {
       if (this.searchResults.length === 0) return null;
@@ -283,23 +233,39 @@ export default defineComponent({
     async searchRequest() {
       this.loadingState = true;
       try {
+        this.searchResults = await this.getSearchResults(false);
+        // this.searchResults = this.searchResults.filter((internship) =>
+        // typeof internship.company.address !== 'undefined');
+      } catch (e: any) {
+        await this.$store.dispatch('addNotification', {
+          text: e.message,
+          type: 'danger',
+        });
+      }
+      try {
+        this.previousSearchResults = await this.getSearchResults(true);
+      } catch (e: any) {
+        await this.$store.dispatch('addNotification', {
+          text: e.message,
+          type: 'danger',
+        });
+      }
+      this.loadingState = false;
+    },
+    async getSearchResults(seen: boolean) {
+      try {
         const res = await http.get('/internships', {
           params: {
             country: this.countryFilter,
             operationalArea: this.operationalAreaFilter,
             programmingLanguage: this.languageFilter,
             paymentType: this.paymentFilter,
-            seen: false,
+            seen,
           },
         });
-        this.searchResults = res.data;
-        this.searchResults = this.searchResults.filter((internship) => typeof internship.company.address !== 'undefined');
-        this.loadingState = false;
+        return res.data;
       } catch (err) {
-        await this.$store.dispatch('addNotification', {
-          text: `Fehler beim Suchen nach Praktika [ERROR: ${err.message}]`,
-          type: 'danger',
-        });
+        throw new Error(`Fehler beim Suchen nach Praktika [ERROR: ${err.message}]`);
       }
     },
   },

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -240,7 +240,7 @@ export default defineComponent({
       try {
         const res = await http.get('/info/countries');
         this.availableCountries = await res.data;
-      } catch (err) {
+      } catch (err) { // Todo: Ersetzen durch util showErrorMessage
         await this.$store.dispatch('addNotification', {
           text: `Fehler beim laden der verfügbaren Länder [ERROR: ${err.message}]`,
           type: 'danger',
@@ -292,7 +292,7 @@ export default defineComponent({
             seen: false,
           },
         });
-        this.searchResults = await res.data;
+        this.searchResults = res.data;
         this.searchResults = this.searchResults.filter((internship) => typeof internship.company.address !== 'undefined');
         this.loadingState = false;
       } catch (err) {

--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -106,8 +106,10 @@
       </form>
     </div>
   </div>
-  <!-- @TODO: Modal mit Hinweis auf begrenzte Suchergebnisanzahl (12) implementieren -->
   <!-- Search Results -->
+  <div id="form-block4" class="mx-3 my-3" v-if="!loadingState && searchResults.length <= 0">
+    {{ $t("search.results.noResults") }}
+  </div>
   <div id="form-block4" class="mx-3 my-3" v-if="!loadingState && searchResults.length > 0">
     <div class="text-center">
       <button type="button"

--- a/server/src/controllers/company.ts
+++ b/server/src/controllers/company.ts
@@ -81,6 +81,8 @@ export async function searchCompanyByName(
     };
   }
 
+  searchOptions.excludedFromSearch = false;
+
   let select = null;
   if (!user.isAdmin) select = "companyName branchName address.country";
 

--- a/server/src/controllers/internship.ts
+++ b/server/src/controllers/internship.ts
@@ -659,7 +659,7 @@ async function saveFile(file: UploadedFile, path: string): Promise<Error | null>
     await fsPromises.mkdir(uploadDir, { recursive: true });
     // Save file
     await file.mv(process.cwd() + "/" + path);
-  } catch (e) {
+  } catch (e: any) {
     return e;
   }
 
@@ -695,7 +695,7 @@ export async function generateRequestPdf(
         res.setHeader("Content-Type", "application/pdf");
         stream.pipe(res);
       });
-  } catch (e) {
+  } catch (e: any) {
     next(new BadRequest(e));
   }
 }

--- a/server/src/controllers/internship.ts
+++ b/server/src/controllers/internship.ts
@@ -177,10 +177,10 @@ export async function findInternships(
   }
 
   if (!user.isAdmin) {
+    options["company.excludedFromSearch"] = false;
     options.status = InternshipStatuses.PASSED;
     if (user.studentProfile?.internshipsSeen) {
-      options["company.excludedFromSearch"] = false;
-      let excludedInternships = user.studentProfile.internship.internships;
+      let excludedInternships = user.studentProfile.internship.internships || [];
       let internshipsSeen = [];
       if (
         (!req.query.seen || req.query.seen === "false") &&

--- a/server/src/controllers/internship.ts
+++ b/server/src/controllers/internship.ts
@@ -245,28 +245,6 @@ export async function findInternships(
     }
   }
 
-  // Query internships that have already been viewed
-  /*
-  let internshipsSeenThatFitFilter = [];
-  if (user.studentProfile) {
-    options._id = {
-      $in: user.studentProfile?.internshipsSeen,
-    };
-
-    internshipsSeenThatFitFilter = await Internship.aggregate([
-      {
-        $lookup: {
-          from: "companies",
-          localField: "company",
-          foreignField: "_id",
-          as: "company",
-        },
-      },
-      { $project: projection },
-      { $match: options },
-    ]);
-  }*/
-
   // Add newly returned internships to internshipsSeen
   if (
     req.query.seen !== "true" &&
@@ -280,9 +258,6 @@ export async function findInternships(
 
   // Return all internships that one has already seen and that fit the filter together with as many
   // as possible other internships that one has not yet seen and that fit the filter
-  // res.json(internships.concat(internshipsSeenThatFitFilter));
-  console.log("Internships " + req.query.seen);
-  console.log(internships.length);
   res.json(internships);
 }
 

--- a/server/src/controllers/internship.ts
+++ b/server/src/controllers/internship.ts
@@ -80,11 +80,11 @@ export async function getRandomInternship(
   let maxOffset = await Internship.count();
   const options: { [k: string]: unknown } = {};
   if (user.studentProfile?.internship) {
+    options["status"] = InternshipStatuses.PASSED;
     if (user.studentProfile.internshipsSeen && user.studentProfile.internshipsSeen.length >= 12) {
       options._id = {
         $in: user.studentProfile.internshipsSeen,
       };
-      options.status = InternshipStatuses.PASSED;
       maxOffset = user.studentProfile.internshipsSeen.length;
     } else {
       options._id = {

--- a/server/src/helpers/pdfHelper.ts
+++ b/server/src/helpers/pdfHelper.ts
@@ -1,0 +1,71 @@
+import { LeanDocument } from "mongoose";
+import { IUser } from "../models/user";
+import { IInternship } from "../models/internship";
+import fsPromises from "fs/promises";
+import { UploadedFile } from "express-fileupload";
+
+/**
+ * Saves an uploaded file to the disk.
+ * @param file The file to save
+ * @param path The path to save the file to
+ * @returns Error|null Returns null if saving the file was successful, otherwise returns error
+ */
+export async function saveFile(file: UploadedFile, path: string): Promise<Error | null> {
+  // Get path without filename
+  const uploadPathParts = path.split("/");
+  uploadPathParts.pop();
+  const uploadDir = uploadPathParts.join("/");
+
+  try {
+    // Create parent directories if necessary
+    await fsPromises.mkdir(uploadDir, { recursive: true });
+    // Save file
+    await file.mv(process.cwd() + "/" + path);
+  } catch (e: any) {
+    return e;
+  }
+
+  return null;
+}
+
+/**
+ * Loads a HTML file template and replaces the placeholders with the user's actual data.
+ * @param fileName The file to load the template from
+ * @param user The user to use for filling in the data
+ * @param internship The internship to use for filling in the data
+ * @returns string The generated HTML template
+ */
+export async function buildHtmlTemplate(
+  fileName: string,
+  user: LeanDocument<IUser>,
+  internship: LeanDocument<IInternship>
+): Promise<string> {
+  const dateFormatter = new Intl.DateTimeFormat("de");
+  const contentHtml = await fsPromises.readFile(`${process.cwd()}/pdf-templates/${fileName}`);
+  const html = contentHtml.toString();
+  return html
+    .replace("{{semester}}", user.studentProfile?.internship.inSemester ?? "")
+    .replace("{{studentId}}", user.studentProfile?.studentId ?? "")
+    .replace("{{firstName}}", user.firstName ?? "")
+    .replace("{{lastName}}", user.lastName ?? "")
+    .replace("{{emailAddress}}", user.emailAddress ?? "")
+    .replace("{{company}}", internship.company.companyName ?? "")
+    .replace(
+      "{{street}}",
+      `${internship.company.address.street ?? ""} ${internship.company.address.streetNumber ?? ""}`
+    )
+    .replace("{{zipCode}}", internship.company.address.zip ?? "")
+    .replace("{{city}}", internship.company.address.city ?? "")
+    .replace("{{country}}", internship.company.address.country ?? "")
+    .replace("{{supervisor}}", internship.supervisor?.fullName ?? "")
+    .replace("{{supervisor.emailAddress}}", internship.supervisor?.emailAddress ?? "")
+    .replace(
+      "{{startDate}}",
+      internship.startDate ? dateFormatter.format(internship.startDate) : ""
+    )
+    .replace("{{endDate}}", internship.endDate ? dateFormatter.format(internship.endDate) : "")
+    .replace("{{semesterOfStudy}}", user.studentProfile?.internship.inSemesterOfStudy ?? "")
+    .replace("{{operationalArea}}", internship.operationalArea ?? "")
+    .replace("{{tasks}}", internship.tasks ?? "")
+    .replace("{{programmingLanguages}}", internship.programmingLanguages?.join(", ") ?? "");
+}

--- a/server/src/helpers/userHelper.ts
+++ b/server/src/helpers/userHelper.ts
@@ -1,0 +1,71 @@
+import { IUser, User } from "../models/user";
+import { Forbidden, NotFound } from "http-errors";
+import { Types } from "mongoose";
+
+interface IPopulate {
+  path: string;
+  lean: boolean;
+  populate?: IPopulate;
+}
+
+/**
+ * Returns the user with the specified email address.
+ * @throws NotFound If the user was not found
+ * @param emailAddress The email address of the user to find.
+ * @param populateCompany Should the company object be fully returned instead of just the id?
+ * @returns IUser The authorized user
+ */
+export async function getUser(emailAddress: string | undefined): Promise<IUser> {
+  if (!emailAddress) throw new NotFound("User not found. No email address was provided.");
+  const user = await User.findOne({ emailAddress: emailAddress }).select("_id isAdmin studentProfile");
+  if (!user) throw new NotFound("User not found");
+  return user;
+}
+
+/**
+ * Returns the user with the specified email address.
+ * @throws NotFound If the user was not found
+ * @param emailAddress The email address of the user to find.
+ * @returns IUser The authorized user
+ */
+export async function getUserWithInternshipModule(
+  emailAddress: string | undefined
+): Promise<IUser> {
+  const user = await getUser(emailAddress);
+  return user.populate("studentProfile.internship");
+}
+
+/**
+ * Returns the authorized user with the specified email address.
+ * @throws NotFound If the user was not found
+ * @throws Forbidden If the user id not authorized to access the internship with the provided id.
+ * @param emailAddress The email address of the user to find.
+ * @param internshipId The internship id to use for the authorization check.
+ * @returns IUser The authorized user
+ */
+export async function getAuthorizedUser(
+  emailAddress: string | undefined,
+  internshipId: string
+): Promise<IUser> {
+  const user: IUser = await getUser(emailAddress);
+  if (!user.isAdmin && !user.hasOwnInternship(internshipId))
+    throw new Forbidden("Student is not authorized for this action");
+  return user;
+}
+
+/**
+ * Returns the authorized user with the specified email address.
+ * @throws NotFound If the user was not found
+ * @throws Forbidden If the user id not authorized to access the internship with the provided id.
+ * @param emailAddress The email address of the user to find.
+ * @param internshipId The internship id to use for the authorization check.
+ * @returns IUser The authorized user
+ */
+export async function getAuthorizedUserWithInternshipModule(
+  emailAddress: string | undefined,
+  internshipId: string
+): Promise<IUser> {
+  const user: IUser = await getUserWithInternshipModule(emailAddress);
+  if (user.isAdmin || user.hasOwnInternship(internshipId)) return user;
+  throw new Forbidden("Student is not authorized for this action");
+}

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,6 +1,7 @@
-import { Document, model, Model, Schema } from "mongoose";
+import {Document, model, Model, Schema, Types} from "mongoose";
 import { IStudentProfile, StudentProfileSchema } from "./studentProfile";
-import { isValidEmail, normalizeEmail } from "../helpers/emailAddressHelper";
+import { isValidEmail } from "../helpers/emailAddressHelper";
+import {IInternship} from "./internship";
 
 export interface IUser extends Document {
   firstName?: string;
@@ -8,6 +9,7 @@ export interface IUser extends Document {
   isAdmin?: boolean;
   emailAddress: string;
   studentProfile?: IStudentProfile;
+  hasOwnInternship(internshipId: string): boolean;
 }
 
 const UserSchema = new Schema({
@@ -38,5 +40,15 @@ const UserSchema = new Schema({
     type: StudentProfileSchema,
   },
 });
+
+UserSchema.methods.hasOwnInternship = function (internshipId: string) {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const internships = this.studentProfile?.internship.internships.map((internship: IInternship) => {
+    return internship._id;
+  });
+
+  return internships.length > 0 && internships.indexOf(internshipId) > -1;
+};
 
 export const User: Model<IUser> = model("User", UserSchema);

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -1,6 +1,6 @@
 import { IUser, User } from "./models/user";
 import * as faker from "faker";
-import { Schema } from "mongoose";
+import {Schema, Types} from "mongoose";
 import { IInternship, Internship } from "./models/internship";
 import { Company } from "./models/company";
 import { companySizes } from "./helpers/companySizes";
@@ -11,8 +11,11 @@ function generateRange(size: number, start?: number): number[] {
   return [...Array(size).keys()].map((i) => i + (start ?? 0));
 }
 
+const ADMIN_USER_ID = Types.ObjectId("0000a0000000000000000000");
+
 async function createAdmin(): Promise<IUser> {
   return await User.create({
+    _id: ADMIN_USER_ID,
     firstName: "Test",
     lastName: "Admin",
     emailAddress: "admin@htw-berlin.de",
@@ -66,7 +69,7 @@ async function createInternship(): Promise<IInternship> {
     comment: faker.lorem.words(10),
   });
 
-  return await Internship.create({
+  const internship = await Internship.create({
     startDate: faker.date.recent(120, "2020-01-01"),
     endDate: faker.date.soon(50, "2021-05-01"),
     company: company.id,
@@ -93,6 +96,11 @@ async function createInternship(): Promise<IInternship> {
       emailAddress: faker.internet.email(),
     },
   });
+
+  // create random number
+  const r = Math.random();
+  if (r < 0.5) return internship.pass(ADMIN_USER_ID);
+  else return internship;
 }
 
 async function generateStudents(

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -1,6 +1,6 @@
 import { IUser, User } from "./models/user";
 import * as faker from "faker";
-import {Schema, Types} from "mongoose";
+import { Schema, Types } from "mongoose";
 import { IInternship, Internship } from "./models/internship";
 import { Company } from "./models/company";
 import { companySizes } from "./helpers/companySizes";

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -99,7 +99,7 @@ async function createInternship(): Promise<IInternship> {
 
   // create random number
   const r = Math.random();
-  if (r < 0.5) return internship.pass(ADMIN_USER_ID);
+  if (r < 0.5) return internship.forcePass(ADMIN_USER_ID);
   else return internship;
 }
 


### PR DESCRIPTION
now, previousely queried internships are displayed with the search results

also refactors the search view to have search result list components, which in turn have search result components

fixes #30 

fixes #247

I changed the logic of the get internship controller a little: It now only gets seen or not-seen internships (depending on the query parameter "seen"), it doesn't add those seen to those unseen. This new logic corresponds to what the front end expects. 