### PR TITLE
Fix 288: Admin Edit Module Details

### DIFF
--- a/client/src/components/internship-module/InternshipModuleIndex.vue
+++ b/client/src/components/internship-module/InternshipModuleIndex.vue
@@ -74,10 +74,10 @@ export default defineComponent({
       return this.loadingState;
     },
     postponements(): Event[] {
-      return this.internshipModule.events.filter((event) => event.changes.status.includes('postponement'));
+      return this.internshipModule.events.filter((event) => event.changes.status?.includes('postponement'));
     },
     plannedInternshipModules(): Event[] {
-      return this.internshipModule.events.filter((event) => event.changes.status.includes('planned'));
+      return this.internshipModule.events.filter((event) => event.changes.status?.includes('planned'));
     },
     hasRequestedPostponements(): boolean {
       return this.postponements.length > 0;


### PR DESCRIPTION
Fixes #288.

Added translations for list of students to make clear what each button does.

Fixed internship module disappering for students after editing module details as admin