### PR TITLE
fix: checking whether supervisor object exists when editing internshi…

### DIFF
--- a/client/src/components/internship/EditInternship.vue
+++ b/client/src/components/internship/EditInternship.vue
@@ -199,8 +199,9 @@ export default defineComponent({
         ?? this.internship?.endDate;
         }
         if (this.supervisor.fullName || this.internship.supervisor?.fullName) {
-          this.internship.supervisor.fullName = this.supervisor.fullName
-        ?? this.internship.supervisor?.fullName;
+          if (!this.internship.supervisor) { this.internship.supervisor = { fullName: this.supervisor.fullName }; } else {
+            this.internship.supervisor.fullName = this.supervisor.fullName ?? this.internship.supervisor?.fullName;
+          }
         }
         if (this.supervisor.emailAddress || this.internship.supervisor?.emailAddress) {
           this.internship.supervisor.emailAddress = this.supervisor.emailAddress

--- a/client/src/components/internship/EditInternship.vue
+++ b/client/src/components/internship/EditInternship.vue
@@ -204,8 +204,10 @@ export default defineComponent({
           }
         }
         if (this.supervisor.emailAddress || this.internship.supervisor?.emailAddress) {
-          this.internship.supervisor.emailAddress = this.supervisor.emailAddress
+          if (!this.internship.supervisor) { this.internship.supervisor = { emailAddress: this.supervisor.emailAddress }; } else {
+            this.internship.supervisor.emailAddress = this.supervisor.emailAddress
         ?? this.internship.supervisor?.emailAddress;
+          }
         }
 
         await http.patch(`/internships/${this.$route.params.id}`, this.internship);


### PR DESCRIPTION
…p part.

Nur ein schneller Fix auf den ich grad gestoßen bin, wenn man ein Internship angelegt hat, aber keinen Supervisor angegeben hat, und beim nächsten Editieren einen hinzufügen will, dann gab es einen undefined Fehler in der Konsole.