### PR TITLE
removing button to permit internship if it's not requested, making it…

### DIFF
--- a/client/src/components/admin/users-list/InternshipPart.vue
+++ b/client/src/components/admin/users-list/InternshipPart.vue
@@ -73,7 +73,7 @@
       </details>
     </div>
     <div class="card-footer">
-      <button class="btn btn-success btn-sm me-2"
+      <button v-if="internship.status === 'requested'" class="btn btn-success btn-sm me-2"
               @click="approveApplication(internship._id)"
       >
         {{ $t("userList.internshipPart.approveApplication") }}
@@ -106,7 +106,7 @@ import { defineComponent, PropType } from 'vue';
 import { getDateString, getTimeDifferenceDays } from '@/utils/admin';
 import { showErrorNotification } from '@/utils/notification';
 import {
-  approveInternshipApplication, deleteComment, deleteInternship, markInternshipAsPassed, updateInternship,
+  approveInternshipApplication, deleteComment, deleteInternship, markInternshipAsForcePassed, markInternshipAsPassed, updateInternship,
 } from '@/utils/gateways';
 import { Comment } from '@/store/types/Comment';
 import { Internship } from '@/store/types/Internship';
@@ -163,9 +163,15 @@ export default defineComponent({
       this.$emit('updateInternship', this.index, updatedInternship);
     },
     async markAsComplete(internshipId: string) {
-      const updatedInternship = await markInternshipAsPassed(internshipId);
+      let updatedInternship = await markInternshipAsPassed(internshipId);
       if (!updatedInternship) {
-        await showErrorNotification('Praktikum konnte nicht als anrechenbar markiert werden.');
+        const userDoubleChecked = window.confirm('Das Praktikum ist noch nicht bereit, '
+        + 'als anrechenbar markiert zu werden, weil gewisse Unterlagen fehlen. Trotzdem als anrechenbar markieren?');
+        if (!userDoubleChecked) return;
+        updatedInternship = await markInternshipAsForcePassed(internshipId);
+        if (!updatedInternship) {
+          await showErrorNotification('Praktikum konnte nicht als anrechenbar markiert werden.');
+        }
         return;
       }
       this.$emit('updateInternship', this.index, updatedInternship);

--- a/client/src/utils/gateways.ts
+++ b/client/src/utils/gateways.ts
@@ -99,6 +99,19 @@ export const markInternshipAsPassed = async (
     const response = await apiClient.patch(`/internships/${internshipId}/pass`);
     return response.data;
   } catch (err: any) {
+    // if (err.response?.data?.error?.message) err.message = err.response.data.error.message;
+    // await showErrorNotification(`Fehler beim Updaten des Praktikums ${internshipId} [ERROR: ${err.message}]`);
+    return null;
+  }
+};
+
+export const markInternshipAsForcePassed = async (
+  internshipId: string,
+): Promise<Internship | null> => {
+  try {
+    const response = await apiClient.patch(`/internships/${internshipId}/forcePass`);
+    return response.data;
+  } catch (err: any) {
     if (err.response?.data?.error?.message) err.message = err.response.data.error.message;
     await showErrorNotification(`Fehler beim Updaten des Praktikums ${internshipId} [ERROR: ${err.message}]`);
     return null;

--- a/server/src/routes/internship.ts
+++ b/server/src/routes/internship.ts
@@ -14,6 +14,7 @@ import {
   markInternshipAsPassed,
   submitPdf,
   updateInternship,
+  markInternshipAsForcePassed,
 } from "../controllers/internship";
 import { isObjectId, validate } from "../helpers/validation";
 import * as asyncHandler from "express-async-handler";
@@ -123,6 +124,14 @@ internshipRouter.patch(
   param("id").custom(isObjectId),
   validate,
   asyncHandler(markInternshipAsPassed)
+);
+
+internshipRouter.patch(
+  "/:id/forcePass",
+  authMiddleware(),
+  param("id").custom(isObjectId),
+  validate,
+  asyncHandler(markInternshipAsForcePassed)
 );
 
 /* PDF endpoints */


### PR DESCRIPTION
… possible to force pass an internship.


@Kaes3kuch3n Was hälst du von dem Vorschlag so? Ich glaube, wir hatten uns mit David geeinigt, dass er kein Praktikum genehmigen kann, wenn noch Sachen fehlen, also hab ich den Button dafür einfach dann disabled.

Beim "Als anrechenbar markieren" bin ich etwas andres verfahren: durch die Praxis hat sich gezeigt, dass man manchmal bei Anerkennungen das Praktikum anerkennt, auch wenn nicht in der Form alle Unterlagen eingereicht wurden, sondern z.b. andere. Deshalb würde ich da ein force-pass erlauben mit erneuter Abfrage. Was denkst du davon?



closes #325 
